### PR TITLE
rename 'countAnyList' to 'lengthAnyList'

### DIFF
--- a/exercise01/src/Exercises.hs
+++ b/exercise01/src/Exercises.hs
@@ -58,8 +58,8 @@ reverseAnyList = undefined
 filterAnyList :: (a -> Bool) -> AnyList -> AnyList
 filterAnyList = undefined
 
-countAnyList :: AnyList -> Int
-countAnyList = undefined
+lengthAnyList :: AnyList -> Int
+lengthAnyList = undefined
 
 foldAnyList :: Monoid m => AnyList -> m
 foldAnyList = undefined


### PR DESCRIPTION
As discussed offline `countAnyList` implies an instance of `Countable` from exercise one, where the intention for `countAnyList` was to create a `length` function for `AnyList`.